### PR TITLE
Fixed the ability to compile to a mojopkg

### DIFF
--- a/csv/string_utils.mojo
+++ b/csv/string_utils.mojo
@@ -144,20 +144,20 @@ fn print_v(v: DynamicVector[UInt64]):
     print("]")
 
 
-fn main():
-    let r = find_indices(
-        "hello world oh my god, this is some great news tight here on the sport", "o"
-    )
-    print_v(r)
-    let c = occurrence_count(
-        "hello world oh my god, this is some great news tight here on the sport",
-        "o",
-        "d",
-    )
-    print(c)
-    let b = contains_any_of(
-        "hello world oh my god, this is some great news tight here on the sport!",
-        "?",
-        "!",
-    )
-    print(b)
+# fn main():
+#     let r = find_indices(
+#         "hello world oh my god, this is some great news tight here on the sport", "o"
+#     )
+#     print_v(r)
+#     let c = occurrence_count(
+#         "hello world oh my god, this is some great news tight here on the sport",
+#         "o",
+#         "d",
+#     )
+#     print(c)
+#     let b = contains_any_of(
+#         "hello world oh my god, this is some great news tight here on the sport!",
+#         "?",
+#         "!",
+#     )
+#     print(b)


### PR DESCRIPTION
Removing the main function in string_utils fixes the issue where using the compiled mojopkg would give an error. Now using ```mojo package csv -o csv.mojopkg``` and using the .mojopkg doesn't give an error when running. From what i understand files in the package can't have main functions, at least for now